### PR TITLE
UISMRCCOMP-6 Change delimiter symbol in source view to match quickMARC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [1.0.0] IN PROGRESS
 
 - [UISMRCCOMP-1](https://issues.folio.org/browse/UISMRCCOMP-1) Module setup.
+- [UISMRCCOMP-6](https://issues.folio.org/browse/UISMRCCOMP-6) Change delimiter symbol in source view to match quickMARC.

--- a/lib/MarcView/MarcField.js
+++ b/lib/MarcView/MarcField.js
@@ -44,7 +44,7 @@ const MarcField = ({
 
       return (
         <Fragment key={`subfield-${index}-${subKey}`}>
-          <span>&#8225;</span>
+          <span>$</span>
           {subKey}
           {' '}
           {subfieldValue}


### PR DESCRIPTION
## Description
Change delimiter symbol in source view to `$`

## Screenshots
![image](https://github.com/folio-org/stripes-marc-components/assets/19309423/6868ca87-b303-42bf-9fdc-9f21e70d5243)

## Issues
[UISMRCCOMP-6](https://issues.folio.org/browse/UISMRCCOMP-6)