### PR TITLE
UISMRCCOMP-7 Use `null` instead of empty string as an empty tenantId value

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -31,11 +31,9 @@ jobs:
       FOLIO_NPM_REGISTRY: "https://repository.folio.org/repository/npm-folio/"
       FOLIO_NPM_REGISTRY_AUTH: "//repository.folio.org/repository/npm-folio/"
       FOLIO_MD_REGISTRY: "https://folio-registry.dev.folio.org"
-      NODEJS_VERSION: "16"
+      NODEJS_VERSION: "18"
       JEST_JUNIT_OUTPUT_DIR: "artifacts/jest-junit"
       JEST_COVERAGE_REPORT_DIR: "artifacts/coverage-jest/lcov-report/"
-      BIGTEST_JUNIT_OUTPUT_DIR: "artifacts/runTest"
-      BIGTEST_COVERAGE_REPORT_DIR: "artifacts/coverage/lcov-report/"
       OKAPI_PULL: '{ "urls" : [ "https://folio-registry.dev.folio.org" ] }'
       SQ_LCOV_REPORT: "artifacts/coverage-jest/lcov.info"
       SQ_EXCLUSIONS: "**/platform/alias-service.js,**/docs/**,**/node_modules/**,**/examples/**,**/artifacts/**,**/ci/**,Jenkinsfile,**/LICENSE,**/*.css,**/*.md,**/*.json,**/tests/**,**/stories/*.js,**/test/**,**/.stories.js,**/resources/bigtest/interactors/**,**/resources/bigtest/network/**,**/*-test.js,**/*.test.js,**/*-spec.js,**/karma.conf.js,**/jest.config.js"
@@ -160,24 +158,6 @@ jobs:
         with:
           name: jest-coverage-report
           path: ${{ env.JEST_COVERAGE_REPORT_DIR }}
-          retention-days: 30
-
-      - name: Publish BigTest unit test results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
-        if: always()
-        with:
-          github_token: ${{ github.token }}
-          files: "${{ env.BIGTEST_JUNIT_OUTPUT_DIR }}/*.xml"
-          check_name: BigTest Unit Test Results
-          comment_mode: update last
-          comment_title: BigTest Unit Test Statistics
-
-      - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: bigtest-coverage-report
-          path: ${{ env.BIGTEST_COVERAGE_REPORT_DIR }}
           retention-days: 30
 
       - name: Publish yarn.lock

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -31,11 +31,9 @@ jobs:
       FOLIO_NPM_REGISTRY: "https://repository.folio.org/repository/npm-folioci/"
       FOLIO_NPM_REGISTRY_AUTH: "//repository.folio.org/repository/npm-folioci/"
       FOLIO_MD_REGISTRY: "https://folio-registry.dev.folio.org"
-      NODEJS_VERSION: "16"
+      NODEJS_VERSION: "18"
       JEST_JUNIT_OUTPUT_DIR: "artifacts/jest-junit"
       JEST_COVERAGE_REPORT_DIR: "artifacts/coverage-jest/lcov-report/"
-      BIGTEST_JUNIT_OUTPUT_DIR: "artifacts/runTest"
-      BIGTEST_COVERAGE_REPORT_DIR: "artifacts/coverage/lcov-report/"
       SQ_LCOV_REPORT: "artifacts/coverage-jest/lcov.info"
       SQ_EXCLUSIONS: "**/platform/alias-service.js,**/docs/**,**/node_modules/**,**/examples/**,**/artifacts/**,**/ci/**,Jenkinsfile,**/LICENSE,**/*.css,**/*.md,**/*.json,**/tests/**,**/stories/*.js,**/test/**,**/.stories.js,**/resources/bigtest/interactors/**,**/resources/bigtest/network/**,**/*-test.js,**/*.test.js,**/*-spec.js,**/karma.conf.js,**/jest.config.js"
 
@@ -106,24 +104,6 @@ jobs:
         with:
           name: jest-coverage-report
           path: ${{ env.JEST_COVERAGE_REPORT_DIR }}
-          retention-days: 30
-
-      - name: Publish BigTest unit test results
-        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
-        if: always()
-        with:
-          github_token: ${{ github.token }}
-          files: "${{ env.BIGTEST_JUNIT_OUTPUT_DIR }}/*.xml"
-          check_name: BigTest Unit Test Results
-          comment_mode: update last
-          comment_title: BigTest Unit Test Statistics
-
-      - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: bigtest-coverage-report
-          path: ${{ env.BIGTEST_COVERAGE_REPORT_DIR }}
           retention-days: 30
 
       - name: Publish yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - [UISMRCCOMP-1](https://issues.folio.org/browse/UISMRCCOMP-1) Module setup.
 - [UISMRCCOMP-6](https://issues.folio.org/browse/UISMRCCOMP-6) Change delimiter symbol in source view to match quickMARC.
+- [UISMRCCOMP-7](https://issues.folio.org/browse/UISMRCCOMP-7) Use `null` instead of empty string as an empty tenantId value.

--- a/lib/MarcView/MarcContent/MarcContent.js
+++ b/lib/MarcView/MarcContent/MarcContent.js
@@ -64,7 +64,7 @@ MarcContent.propTypes = propTypes;
 
 MarcContent.defaultProps = {
   isPrint: false,
-  tenantId: '',
+  tenantId: null,
 };
 
 export { MarcContent };

--- a/lib/MarcView/MarcField.js
+++ b/lib/MarcView/MarcField.js
@@ -119,7 +119,7 @@ MarcField.propTypes = propTypes;
 
 MarcField.defaultProps = {
   isPrint: false,
-  tenantId: '',
+  tenantId: null,
 };
 
 export { MarcField };

--- a/lib/MarcView/MarcView.js
+++ b/lib/MarcView/MarcView.js
@@ -78,7 +78,7 @@ MarcView.defaultProps = {
   paneHeight: null,
   paneSub: '',
   paneWidth: '',
-  tenantId: '',
+  tenantId: null,
 };
 
 export { MarcView };


### PR DESCRIPTION
## Description
`useOkapiKy` uses `??` operator instead of `||`, so an empty value needs to be null for default tenant id to be applied

## Screenshots

https://github.com/folio-org/stripes-marc-components/assets/19309423/191f2710-2367-4121-af2d-cb95af8ce898


## Issues
[UISMRCCOMP-7](https://folio-org.atlassian.net/browse/UISMRCCOMP-7)