### PR TITLE
UISMRCCOMP-10 MarcView - do not re-order 00X fields to be shown first.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-marc-components
 
+## [1.0.1] (IN PROGRESS)
+
+- [UISMRCCOMP-10](https://issues.folio.org/browse/UISMRCCOMP-10) MarcView - do not re-order 00X fields to be shown first.
+
 ## [1.0.0] (https://github.com/folio-org/stripes-marc-components/tree/v1.0.0) (2024-03-21)
 
 - [UISMRCCOMP-1](https://issues.folio.org/browse/UISMRCCOMP-1) Module setup.

--- a/lib/MarcView/MarcContent/MarcContent.js
+++ b/lib/MarcView/MarcContent/MarcContent.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Headline } from '@folio/stripes/components';
 
 import { MarcField } from '../MarcField';
-import { isControlField } from '../utils';
+
 import styles from './MarcContent.css';
 
 const propTypes = {

--- a/lib/MarcView/MarcContent/MarcContent.js
+++ b/lib/MarcView/MarcContent/MarcContent.js
@@ -21,13 +21,6 @@ const MarcContent = ({
 }) => {
   const showLinkIcon = marc.recordType === 'MARC_BIB';
   const parsedContent = marc.parsedRecord.content;
-  const parsedMarc = {
-    leader: parsedContent.leader,
-    fields: [
-      ...parsedContent.fields.filter(isControlField),
-      ...parsedContent.fields.filter(field => !isControlField(field)),
-    ],
-  };
 
   return (
     <section className={styles.marcWrapper}>
@@ -42,10 +35,10 @@ const MarcContent = ({
         <tbody>
           <tr>
             <td colSpan="4">
-              {`LEADER ${parsedMarc.leader}`}
+              {`LEADER ${parsedContent.leader}`}
             </td>
           </tr>
-          {parsedMarc.fields.map((field, idx) => (
+          {parsedContent.fields.map((field, idx) => (
             <MarcField
               isPrint={isPrint}
               field={field}

--- a/lib/MarcView/MarcContent/MarcContent.test.js
+++ b/lib/MarcView/MarcContent/MarcContent.test.js
@@ -7,7 +7,7 @@ import Harness from '../../../test/jest/helpers/harness';
 import { MarcContent } from './MarcContent';
 
 jest.mock('../MarcField', () => ({
-  MarcField: jest.fn(() => <tr><td>MarcField</td></tr>),
+  MarcField: jest.fn(({ field }) => <tr><td>MarcField {JSON.stringify(field)}</td></tr>),
 }));
 
 const marc = {
@@ -16,6 +16,8 @@ const marc = {
     content: {
       fields: [{
         '001': 'in00000000140',
+      }, {
+        '852': '$b E',
       }, {
         '008': '120126r20122010nyu      b    001 0 eng  ',
       }],
@@ -63,6 +65,16 @@ describe('Given MarcContent', () => {
   it('should render list of marc fields', () => {
     const { getAllByText } = renderMarcContent();
 
-    expect(getAllByText('MarcField').length).toBe(2);
+    expect(getAllByText(/MarcField/).length).toBe(3);
+  });
+
+  it('should display fields in order provided in props', () => {
+    const { getAllByRole } = renderMarcContent();
+
+    const rows = getAllByRole('row');
+
+    expect(rows[1].textContent.includes('"001"')).toBeTruthy();
+    expect(rows[2].textContent.includes('"852"')).toBeTruthy();
+    expect(rows[3].textContent.includes('"008"')).toBeTruthy();
   });
 });

--- a/lib/MarcView/utils.js
+++ b/lib/MarcView/utils.js
@@ -1,3 +1,1 @@
-export const isControlField = field => (Object.keys(field)[0]).startsWith('00');
-
 export const normalizeIndicator = indictor => indictor.replace(/\\/g, ' ');


### PR DESCRIPTION
## Description
Remove ordering of Marc fields, so that field order is the same when editing and viewing MARC records

## Screenshots
**Edit view**
![image](https://github.com/folio-org/stripes-marc-components/assets/19309423/74dc8478-9175-43f1-9409-3c42605a6b7c)


**Source view**
![image](https://github.com/folio-org/stripes-marc-components/assets/19309423/40e43eef-8988-4351-97f7-0d434c5e6d57)

## Issues
[UISMRCCOMP-10](https://folio-org.atlassian.net/browse/UISMRCCOMP-10)