### PR TITLE
UISMRCCOMP-15 Provide the `actionMenu` property for the `MarcView` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 - [UISMRCCOMP-14](https://issues.folio.org/browse/UISMRCCOMP-14) Provide the `firstMenu` property for the `MarcView` component.
+- [UISMRCCOMP-15](https://issues.folio.org/browse/UISMRCCOMP-15) Provide the `actionMenu` property for the `MarcView` component.
 
 ## [1.0.1] (https://github.com/folio-org/stripes-marc-components/tree/v1.0.1) (2024-04-16)
 

--- a/lib/MarcView/MarcView.js
+++ b/lib/MarcView/MarcView.js
@@ -9,6 +9,7 @@ import {
 import { MarcContent } from './MarcContent';
 
 const propTypes = {
+  actionMenu: PropTypes.node,
   firstMenu: PropTypes.element,
   isPaneset: PropTypes.bool,
   lastMenu: PropTypes.node,
@@ -40,6 +41,7 @@ const MarcView = ({
   lastMenu,
   isPaneset,
   tenantId,
+  actionMenu,
 }) => {
   const renderContent = () => (
     <Pane
@@ -54,6 +56,7 @@ const MarcView = ({
       height={paneHeight}
       firstMenu={firstMenu}
       lastMenu={lastMenu}
+      actionMenu={actionMenu}
     >
       <MarcContent
         marcTitle={marcTitle}
@@ -85,6 +88,7 @@ MarcView.defaultProps = {
   paneSub: '',
   paneWidth: '',
   tenantId: null,
+  actionMenu: null,
 };
 
 export { MarcView };


### PR DESCRIPTION
## Description
Provide the `actionMenu` property for the `MarcView` component.

## Issues
[UISMRCCOMP-15](https://folio-org.atlassian.net/browse/UISMRCCOMP-15)