### PR TITLE
UISMRCCOMP-23 Add a `wrapperClass` prop to `<MarcView>` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [UISMRCCOMP-19](https://issues.folio.org/browse/UISMRCCOMP-19) *BREAKING* migrate stripes dependencies to their Sunflower versions.
 - [UISMRCCOMP-20](https://issues.folio.org/browse/UISMRCCOMP-20) *BREAKING* migrate react-intl to v7.
-
+- [UISMRCCOMP-23](https://issues.folio.org/browse/UISMRCCOMP-23) Add a `wrapperClass` prop to `<MarcView>` component
 
 ## [1.1.0] (https://github.com/folio-org/stripes-marc-components/tree/v1.1.0) (2024-10-31)
 

--- a/lib/MarcView/MarcContent/MarcContent.js
+++ b/lib/MarcView/MarcContent/MarcContent.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { Headline } from '@folio/stripes/components';
 
@@ -11,6 +12,7 @@ const propTypes = {
   marc: PropTypes.object.isRequired,
   marcTitle: PropTypes.node.isRequired,
   tenantId: PropTypes.string,
+  wrapperClass: PropTypes.string,
 };
 
 const MarcContent = ({
@@ -18,12 +20,13 @@ const MarcContent = ({
   marc,
   isPrint,
   tenantId,
+  wrapperClass,
 }) => {
   const showLinkIcon = marc.recordType === 'MARC_BIB';
   const parsedContent = marc.parsedRecord.content;
 
   return (
-    <section className={styles.marcWrapper}>
+    <section className={classNames([styles.marcWrapper, wrapperClass])}>
       <Headline
         size="large"
         margin="small"
@@ -58,6 +61,7 @@ MarcContent.propTypes = propTypes;
 MarcContent.defaultProps = {
   isPrint: false,
   tenantId: null,
+  wrapperClass: null,
 };
 
 export { MarcContent };

--- a/lib/MarcView/MarcView.js
+++ b/lib/MarcView/MarcView.js
@@ -27,6 +27,7 @@ const propTypes = {
   ]).isRequired,
   paneWidth: PropTypes.string,
   tenantId: PropTypes.string,
+  wrapperClass: PropTypes.string,
 };
 
 const MarcView = ({
@@ -42,6 +43,7 @@ const MarcView = ({
   isPaneset,
   tenantId,
   actionMenu,
+  wrapperClass,
 }) => {
   const renderContent = () => (
     <Pane
@@ -62,6 +64,7 @@ const MarcView = ({
         marcTitle={marcTitle}
         marc={marc}
         tenantId={tenantId}
+        wrapperClass={wrapperClass}
       />
     </Pane>
   );
@@ -89,6 +92,7 @@ MarcView.defaultProps = {
   paneWidth: '',
   tenantId: null,
   actionMenu: null,
+  wrapperClass: null,
 };
 
 export { MarcView };


### PR DESCRIPTION
## Description
Add a `wrapperClass` prop to `<MarcView>` component to be able to configure styling of MARC view from outside the component

## Issues
[UISMRCCOMP-23](https://folio-org.atlassian.net/browse/UISMRCCOMP-23)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2749