### PR TITLE
UISMRCCOMP-27: Pass `showUserLink` prop for `AuditLogPane`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UISMRCCOMP-23](https://issues.folio.org/browse/UISMRCCOMP-23) Add a `wrapperClass` prop to `<MarcView>` component
 - [UISMRCCOMP-13](https://issues.folio.org/browse/UISMRCCOMP-13) React v19: refactor away from default props for functional components.
 - [UISMRCCOMP-26](https://issues.folio.org/browse/UISMRCCOMP-26) *BREAKING* Added `<MarcVersionHistory>` and `useMarcAuditDataQuery`.
+- [UISMRCCOMP-27](https://issues.folio.org/browse/UISMRCCOMP-27) Pass `showUserLink` prop for `AuditLogPane`.
 
 ## [1.1.0] (https://github.com/folio-org/stripes-marc-components/tree/v1.1.0) (2024-10-31)
 

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import uniq from 'lodash/uniq';
 import keyBy from 'lodash/keyBy';
 
+import { useStripes } from '@folio/stripes/core';
 import {
   AuditLogPane,
   useVersionHistory,
@@ -31,6 +32,7 @@ const MarcVersionHistory = ({
   id,
   onClose,
 }) => {
+  const stripes = useStripes();
   const intl = useIntl();
   const [usersMap, setUsersMap] = useState({});
   const [lastVersionEventTs, setLastVersionEventTs] = useState(null);
@@ -41,6 +43,7 @@ const MarcVersionHistory = ({
   } = useMarcAuditDataQuery(id, marcType, lastVersionEventTs);
 
   const usersId = useMemo(() => uniq(data?.map(version => version.userId)), [data]);
+  const hasUsersViewPerm = stripes.hasPerm('ui-users.view');
 
   const { users } = useUsersBatch(usersId);
 
@@ -77,6 +80,7 @@ const MarcVersionHistory = ({
       actionsMap={actionsMap}
       onClose={onClose}
       isLoading={isLoading}
+      showUserLink={hasUsersViewPerm}
     />
   );
 };

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -65,7 +65,7 @@ const MarcVersionHistory = ({
   } = useVersionHistory({
     data,
     totalRecords,
-    versionsFormatter: versionsFormatter(usersMap, intl),
+    versionsFormatter: versionsFormatter(usersMap, intl, hasUsersViewPerm),
   });
 
   const handleLoadMore = lastEventTs => {
@@ -80,7 +80,6 @@ const MarcVersionHistory = ({
       actionsMap={actionsMap}
       onClose={onClose}
       isLoading={isLoading}
-      showUserLink={hasUsersViewPerm}
     />
   );
 };

--- a/lib/MarcVersionHistory/MarcVersionHistory.test.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.test.js
@@ -1,8 +1,4 @@
-import {
-  QueryClient,
-  QueryClientProvider,
-} from 'react-query';
-
+import { useStripes } from '@folio/stripes/core';
 import {
   fireEvent,
   render,
@@ -11,6 +7,14 @@ import {
 
 import { MarcVersionHistory } from './MarcVersionHistory';
 import { useMarcAuditDataQuery } from '../queries';
+import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
+import Harness from '../../test/jest/helpers/harness';
+
+const mockHasPerm = jest.fn().mockReturnValue(true);
+
+useStripes.mockReturnValue(buildStripes({
+  hasPerm: mockHasPerm,
+}));
 
 jest.mock('../queries', () => ({
   ...jest.requireActual('../queries'),
@@ -19,6 +23,7 @@ jest.mock('../queries', () => ({
       eventDate: '1970-01-01T00:00:00+00:00',
       action: 'UPDATED',
       eventTs: 1741264744302,
+      userId: 'user-id',
       diff: {
         collectionChanges: [{
           'collectionName': '750',
@@ -65,23 +70,25 @@ jest.mock('../queries', () => ({
   }),
 }));
 
-const queryClient = new QueryClient();
-
 const onCloseMock = jest.fn();
 const marcId = 'marcId';
 
 const renderMarcVersionHistory = () => render(
-  <QueryClientProvider client={queryClient}>
+  <Harness>
     <MarcVersionHistory
       id={marcId}
       onClose={onCloseMock}
       marcType="bib"
     />
-  </QueryClientProvider>,
+  </Harness>,
 );
 
 describe('MarcVersionHistory', () => {
   const scrollIntoViewOriginal = Element.prototype.scrollIntoView;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   beforeAll(() => {
     Element.prototype.scrollIntoView = jest.fn();
@@ -107,6 +114,25 @@ describe('MarcVersionHistory', () => {
       const eventTs = 1741264744302; // timestamp of unix time
 
       expect(useMarcAuditDataQuery).toHaveBeenCalledWith(marcId, 'bib', eventTs);
+    });
+  });
+
+  describe('when there is a user view permission', () => {
+    it('should display username as a link', async () => {
+      renderMarcVersionHistory();
+
+      expect(screen.getByRole('link', { name: 'lastName, firstName' })).toBeInTheDocument();
+    });
+  });
+
+  describe('when there is no a user view permission', () => {
+    it('should display username as not a link', async () => {
+      mockHasPerm.mockReturnValue(false);
+
+      renderMarcVersionHistory();
+
+      expect(screen.queryByRole('link', { name: 'lastName, firstName' })).toBeNull();
+      expect(screen.getByText('lastName, firstName')).toBeInTheDocument();
     });
   });
 });

--- a/lib/MarcVersionHistory/MarcVersionHistory.test.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.test.js
@@ -101,7 +101,7 @@ describe('MarcVersionHistory', () => {
   it('should render Version history pane', () => {
     renderMarcVersionHistory();
 
-    expect(screen.getByText('stripes-components.versionHistory.pane.header')).toBeInTheDocument();
+    expect(screen.getByText('stripes-components.auditLog.pane.header')).toBeInTheDocument();
   });
 
   describe('when clicking on Load more button', () => {
@@ -118,7 +118,7 @@ describe('MarcVersionHistory', () => {
   });
 
   describe('when there is a user view permission', () => {
-    it('should display username as a link', async () => {
+    it('should display username as a link', () => {
       renderMarcVersionHistory();
 
       expect(screen.getByRole('link', { name: 'lastName, firstName' })).toBeInTheDocument();
@@ -126,7 +126,7 @@ describe('MarcVersionHistory', () => {
   });
 
   describe('when there is no a user view permission', () => {
-    it('should display username as not a link', async () => {
+    it('should display username as not a link', () => {
       mockHasPerm.mockReturnValue(false);
 
       renderMarcVersionHistory();

--- a/lib/MarcVersionHistory/utils.js
+++ b/lib/MarcVersionHistory/utils.js
@@ -51,7 +51,9 @@ export const versionsFormatter = (usersMap, intl, hasUsersViewPerm) => diffArray
   const getUserName = userId => {
     const user = usersMap[userId];
 
-    return user ? `${user.personal.lastName}, ${user.personal.firstName}` : null;
+    return user
+      ? [user.personal.lastName, user.personal.firstName].filter(v => v).join(', ')
+      : null;
   };
 
   const getSourceLink = userId => {

--- a/lib/MarcVersionHistory/utils.js
+++ b/lib/MarcVersionHistory/utils.js
@@ -45,7 +45,7 @@ export const getChangedFieldsList = (diff, formatMessage) => {
   return sortBy([...fieldChanges, ...collectionChanges], data => data.changeType);
 };
 
-export const versionsFormatter = (usersMap, intl) => diffArray => {
+export const versionsFormatter = (usersMap, intl, hasUsersViewPerm) => diffArray => {
   const anonymousUserLabel = intl.formatMessage({ id: 'stripes-marc-components.versionHistory.anonymousUser' });
 
   const getUserName = userId => {
@@ -55,7 +55,17 @@ export const versionsFormatter = (usersMap, intl) => diffArray => {
   };
 
   const getSourceLink = userId => {
-    return userId ? <Link to={`/users/preview/${userId}`}>{getUserName(userId)}</Link> : anonymousUserLabel;
+    if (!userId) {
+      return anonymousUserLabel;
+    }
+
+    const username = getUserName(userId);
+
+    if (!hasUsersViewPerm) {
+      return username;
+    }
+
+    return <Link to={`/users/preview/${userId}`}>{username}</Link>;
   };
 
   return diffArray

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -7,3 +7,4 @@ import './stripesIcon.mock';
 import './stripesSmartComponent.mock';
 import './matchMedia.mock';
 import './react-virtualized-auto-sizer.mock';
+import './stripesAcqComponents.mock';

--- a/test/jest/__mock__/reactIntl.mock.js
+++ b/test/jest/__mock__/reactIntl.mock.js
@@ -6,12 +6,19 @@ jest.mock('react-intl', () => {
 
   return {
     ...jest.requireActual('react-intl'),
-    FormattedMessage: jest.fn(({ id, children }) => {
+    FormattedMessage: jest.fn(({ id, children, values }) => {
       if (children) {
         return children([id]);
       }
 
-      return id;
+      return (
+        <>
+          {id}
+          {values && Object.entries(values).map(([key, value]) => (
+            <span key={key}>{value}</span>
+          ))}
+        </>
+      );
     }),
     FormattedTime: jest.fn(({ value, children }) => {
       if (children) {

--- a/test/jest/__mock__/stripesAcqComponents.mock.js
+++ b/test/jest/__mock__/stripesAcqComponents.mock.js
@@ -1,0 +1,15 @@
+jest.mock('@folio/stripes-acq-components', () => ({
+  ...jest.requireActual('@folio/stripes-acq-components'),
+  useUsersBatch: jest.fn().mockReturnValue({
+    users: [
+      {
+        username: 'username',
+        id: 'user-id',
+        personal: {
+          lastName: 'lastName',
+          firstName: 'firstName',
+        },
+      },
+    ],
+  }),
+}));

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -83,7 +83,7 @@ jest.mock('@folio/stripes/core', () => {
     return <Component {...rest} stripes={fakeStripes} />;
   };
 
-  const useStripes = () => STRIPES;
+  const useStripes = jest.fn(() => STRIPES);
 
   // eslint-disable-next-line react/prop-types
   const IfPermission = ({ children }) => <>{children}</>;


### PR DESCRIPTION
## Purpose
If a user does not have the appropriate permissions to view User records, make the user name hyperlink inactive (show plain text) on the change history card.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Issues
[UISMRCCOMP-27](https://folio-org.atlassian.net/browse/UISMRCCOMP-27)

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots

![image](https://github.com/user-attachments/assets/48222f3a-e4de-4d1e-817b-fa05f1d61c16)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
