### PR TITLE
UISMRCCOMP-28: Use tenantId in useMarcAuditDataQuery, pass totalRecords and columnWidths to AuditLogPane.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [UISMRCCOMP-13](https://issues.folio.org/browse/UISMRCCOMP-13) React v19: refactor away from default props for functional components.
 - [UISMRCCOMP-26](https://issues.folio.org/browse/UISMRCCOMP-26) *BREAKING* Added `<MarcVersionHistory>` and `useMarcAuditDataQuery`.
 - [UISMRCCOMP-27](https://issues.folio.org/browse/UISMRCCOMP-27) Pass `showUserLink` prop for `AuditLogPane`.
+- [UISMRCCOMP-28](https://issues.folio.org/browse/UISMRCCOMP-28) Use `tenantId` in `useMarcAuditDataQuery`, pass `totalRecords` and `columnWidths` to `AuditLogPane`.
 
 ## [1.1.0] (https://github.com/folio-org/stripes-marc-components/tree/v1.1.0) (2024-10-31)
 

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -20,17 +20,20 @@ import {
   versionsFormatter,
   getActionLabel,
 } from './utils';
+import { MODAL_COLUMN_WIDTHS } from './constants';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
   marcType: PropTypes.oneOf(['bib', 'authority']).isRequired,
   onClose: PropTypes.func.isRequired,
+  tenantId: PropTypes.string.isRequired,
 };
 
 const MarcVersionHistory = ({
   marcType,
   id,
   onClose,
+  tenantId,
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
@@ -40,7 +43,7 @@ const MarcVersionHistory = ({
     data,
     totalRecords,
     isLoading,
-  } = useMarcAuditDataQuery(id, marcType, lastVersionEventTs);
+  } = useMarcAuditDataQuery(id, marcType, lastVersionEventTs, tenantId);
 
   const usersId = useMemo(() => uniq(data?.map(version => version.userId)), [data]);
   const hasUsersViewPerm = stripes.hasPerm('ui-users.view');
@@ -79,7 +82,9 @@ const MarcVersionHistory = ({
       handleLoadMore={handleLoadMore}
       actionsMap={actionsMap}
       onClose={onClose}
+      totalVersions={totalRecords}
       isLoading={isLoading}
+      columnWidths={MODAL_COLUMN_WIDTHS}
     />
   );
 };

--- a/lib/MarcVersionHistory/MarcVersionHistory.test.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.test.js
@@ -11,6 +11,7 @@ import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
 import Harness from '../../test/jest/helpers/harness';
 
 const mockHasPerm = jest.fn().mockReturnValue(true);
+const totalRecords = 123;
 
 useStripes.mockReturnValue(buildStripes({
   hasPerm: mockHasPerm,
@@ -65,7 +66,7 @@ jest.mock('../queries', () => ({
         ],
       },
     }],
-    totalRecords: 10,
+    totalRecords,
     isLoading: false,
   }),
 }));
@@ -79,6 +80,7 @@ const renderMarcVersionHistory = () => render(
       id={marcId}
       onClose={onCloseMock}
       marcType="bib"
+      tenantId="tenant-id"
     />
   </Harness>,
 );
@@ -113,7 +115,7 @@ describe('MarcVersionHistory', () => {
 
       const eventTs = 1741264744302; // timestamp of unix time
 
-      expect(useMarcAuditDataQuery).toHaveBeenCalledWith(marcId, 'bib', eventTs);
+      expect(useMarcAuditDataQuery).toHaveBeenCalledWith(marcId, 'bib', eventTs, 'tenant-id');
     });
   });
 
@@ -134,6 +136,12 @@ describe('MarcVersionHistory', () => {
       expect(screen.queryByRole('link', { name: 'lastName, firstName' })).toBeNull();
       expect(screen.getByText('lastName, firstName')).toBeInTheDocument();
     });
+  });
+
+  it('should render the total number of records in a header', () => {
+    renderMarcVersionHistory();
+
+    expect(screen.getByText(totalRecords)).toBeInTheDocument();
   });
 });
 

--- a/lib/MarcVersionHistory/constants.js
+++ b/lib/MarcVersionHistory/constants.js
@@ -9,3 +9,10 @@ export const AUDIT_FIELD_ACTIONS = {
   MODIFIED: 'MODIFIED',
   REMOVED: 'REMOVED',
 };
+
+export const MODAL_COLUMN_WIDTHS = {
+  action: '8%',
+  field: '6%',
+  changedFrom: '38%',
+  changedTo: '38%',
+};

--- a/lib/MarcVersionHistory/utils.js
+++ b/lib/MarcVersionHistory/utils.js
@@ -71,7 +71,7 @@ export const versionsFormatter = (usersMap, intl, hasUsersViewPerm) => diffArray
   };
 
   return diffArray.map(({ action, eventDate, eventTs, userId, eventId, diff }) => {
-    const modalFieldChanges = diff ? getChangedFieldsList(diff, intl.formatMessage) : [];
+    const modalFieldChanges = diff ? getChangedFieldsList(diff) : [];
 
     const cardFieldChanges = uniqBy(modalFieldChanges, field => `${field.fieldName}-${field.changeType}`)
       .map(field => ({

--- a/lib/MarcVersionHistory/utils.js
+++ b/lib/MarcVersionHistory/utils.js
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
 
 import { formatDateTime } from '@folio/stripes-acq-components';
 
@@ -16,15 +17,14 @@ const prefixFieldName = (field, formatMessage) => formatMessage(
 /**
  * Merge fieldChanges and collectionChanges into a list of changed fields and sort by changeType
  * @param {Object} diff
- * @param {Function} formatMessage
  * @param {Array} diff.fieldChanges
  * @param {Array} diff.collectionChanges
  * @returns {Array.<{fieldName: String, changeType: String, newValue: any, oldValue: any}>}
  */
-export const getChangedFieldsList = (diff, formatMessage) => {
+export const getChangedFieldsList = diff => {
   const fieldChanges = diff.fieldChanges ?
     diff.fieldChanges.map(field => ({
-      fieldName: prefixFieldName(field.fieldName, formatMessage),
+      fieldName: field.fieldName,
       changeType: field.changeType,
       newValue: field.newValue,
       oldValue: field.oldValue,
@@ -34,7 +34,7 @@ export const getChangedFieldsList = (diff, formatMessage) => {
   const collectionChanges = diff.collectionChanges ?
     diff.collectionChanges.flatMap(collection => {
       return collection.itemChanges.map(field => ({
-        fieldName: prefixFieldName(collection.collectionName, formatMessage),
+        fieldName: collection.collectionName,
         changeType: field.changeType,
         newValue: field.newValue,
         oldValue: field.oldValue,
@@ -70,16 +70,26 @@ export const versionsFormatter = (usersMap, intl, hasUsersViewPerm) => diffArray
     return <Link to={`/users/preview/${userId}`}>{username}</Link>;
   };
 
-  return diffArray
-    .map(({ action, eventDate, eventTs, userId, eventId, diff }) => ({
+  return diffArray.map(({ action, eventDate, eventTs, userId, eventId, diff }) => {
+    const modalFieldChanges = diff ? getChangedFieldsList(diff, intl.formatMessage) : [];
+
+    const cardFieldChanges = uniqBy(modalFieldChanges, field => `${field.fieldName}-${field.changeType}`)
+      .map(field => ({
+        ...field,
+        fieldName: prefixFieldName(field.fieldName, intl.formatMessage),
+      }));
+
+    return {
       isOriginal: action === AUDIT_COLLECTION_ACTIONS.CREATED,
       eventDate: formatDateTime(eventDate, intl),
       source: getSourceLink(userId),
       userName: getUserName(userId) || anonymousUserLabel,
-      fieldChanges: diff ? getChangedFieldsList(diff, intl.formatMessage) : [],
+      modalFieldChanges,
+      fieldChanges: cardFieldChanges,
       eventId,
       eventTs,
-    }));
+    };
+  });
 };
 
 /**

--- a/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
+++ b/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
@@ -5,13 +5,13 @@ import {
   useOkapiKy,
 } from '@folio/stripes/core';
 
-export const useMarcAuditDataQuery = (id, marcType, eventTs) => {
-  const ky = useOkapiKy();
+export const useMarcAuditDataQuery = (id, marcType, eventTs, tenantId) => {
+  const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'marc-audit-data' });
 
   // eventTs param is used to load more data
   const { isLoading, data = {} } = useQuery({
-    queryKey: [namespace, id, marcType, eventTs],
+    queryKey: [namespace, id, marcType, eventTs, tenantId],
     queryFn: () => ky.get(`audit-data/marc/${marcType}/${id}`, {
       searchParams: {
         ...(eventTs && { eventTs }),


### PR DESCRIPTION
## Purpose
- group field changes if action and tag match;
- remove "Field" prefix for card modal window; 
- retrieve a shared record history from central tenant, a local record history from member tenant;
- display the total number of records in the history pane header;
- remove horizontal scrolling for a modal window of card.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Related PRs
https://github.com/folio-org/stripes-components/pull/2440

## Issues
https://folio-org.atlassian.net/browse/UISMRCCOMP-28

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots

https://github.com/user-attachments/assets/ab745e1c-3b00-4637-b7ea-9665bedba5d4



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
