### PR TITLE
UISMRCCOMP-28: MarcVersionHistory - display totalVersions instead of undefined during loading (follow-up).

### DIFF
--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -39,6 +39,8 @@ const MarcVersionHistory = ({
   const intl = useIntl();
   const [usersMap, setUsersMap] = useState({});
   const [lastVersionEventTs, setLastVersionEventTs] = useState(null);
+  const [totalVersions, setTotalVersions] = useState(0);
+
   const {
     data,
     totalRecords,
@@ -71,6 +73,13 @@ const MarcVersionHistory = ({
     versionsFormatter: versionsFormatter(usersMap, intl, hasUsersViewPerm),
   });
 
+  useEffect(() => {
+    // totalRecords always returns undefined while loading, and we need to display the total number of versions.
+    if (totalRecords) {
+      setTotalVersions(totalRecords);
+    }
+  }, [totalRecords]);
+
   const handleLoadMore = lastEventTs => {
     setLastVersionEventTs(lastEventTs);
   };
@@ -82,7 +91,7 @@ const MarcVersionHistory = ({
       handleLoadMore={handleLoadMore}
       actionsMap={actionsMap}
       onClose={onClose}
-      totalVersions={totalRecords}
+      totalVersions={totalVersions}
       isLoading={isLoading}
       columnWidths={MODAL_COLUMN_WIDTHS}
     />


### PR DESCRIPTION

## Description
`totalRecords` always returns `undefined` while loading, and we need to display the total number of versions. Let's display the previous number, keeping it in that state until the new one is returned.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots

https://github.com/user-attachments/assets/901d9475-c830-46c0-b167-85a6d9a88ee0




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
