### PR TITLE
UISMRCCOMP-28: Pass totalVersions to useVersionHistory to display loading for LoadMore button (follow-up).

### DIFF
--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -69,7 +69,7 @@ const MarcVersionHistory = ({
     isLoadMoreVisible,
   } = useVersionHistory({
     data,
-    totalRecords,
+    totalRecords: totalVersions,
     versionsFormatter: versionsFormatter(usersMap, intl, hasUsersViewPerm),
   });
 

--- a/lib/MarcVersionHistory/MarcVersionHistory.test.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.test.js
@@ -19,77 +19,83 @@ useStripes.mockReturnValue(buildStripes({
 
 jest.mock('../queries', () => ({
   ...jest.requireActual('../queries'),
-  useMarcAuditDataQuery: jest.fn().mockReturnValue({
-    data: [{
-      eventDate: '1970-01-01T00:00:00+00:00',
-      action: 'UPDATED',
-      eventTs: 1741264744302,
-      userId: 'user-id',
-      diff: {
-        collectionChanges: [{
-          'collectionName': '750',
-          'itemChanges': [
-            {
-              'changeType': 'REMOVED',
-              'oldValue': ' 0 $a Black people $0 (DLC)sh 85014672 ',
-              'newValue': null,
-            },
-            {
-              'changeType': 'ADDED',
-              'oldValue': null,
-              'newValue': ' 0 $a Black people $0 (DLC)sh 85014672',
-            },
-          ],
-        }],
-        fieldChanges: [
+  useMarcAuditDataQuery: jest.fn(),
+}));
+
+const auditDataResponse = {
+  data: [{
+    eventDate: '1970-01-01T00:00:00+00:00',
+    action: 'UPDATED',
+    eventTs: 1741264744302,
+    userId: 'user-id',
+    diff: {
+      collectionChanges: [{
+        'collectionName': '750',
+        'itemChanges': [
           {
-            'changeType': 'MODIFIED',
-            'fieldName': '150',
-            'fullPath': '150',
-            'oldValue': '   $a foo',
-            'newValue': '   $a foo test',
+            'changeType': 'REMOVED',
+            'oldValue': ' 0 $a Black people $0 (DLC)sh 85014672 ',
+            'newValue': null,
           },
           {
-            'changeType': 'MODIFIED',
-            'fieldName': '003',
-            'fullPath': '003',
-            'oldValue': 'OCoLC',
-            'newValue': '$a OCoLC',
-          },
-          {
-            'changeType': 'MODIFIED',
-            'fieldName': 'LDR',
-            'fullPath': 'LDR',
-            'oldValue': '123  4500',
-            'newValue': '1234',
+            'changeType': 'ADDED',
+            'oldValue': null,
+            'newValue': ' 0 $a Black people $0 (DLC)sh 85014672',
           },
         ],
-      },
-    }],
-    totalRecords,
-    isLoading: false,
-  }),
-}));
+      }],
+      fieldChanges: [
+        {
+          'changeType': 'MODIFIED',
+          'fieldName': '150',
+          'fullPath': '150',
+          'oldValue': '   $a foo',
+          'newValue': '   $a foo test',
+        },
+        {
+          'changeType': 'MODIFIED',
+          'fieldName': '003',
+          'fullPath': '003',
+          'oldValue': 'OCoLC',
+          'newValue': '$a OCoLC',
+        },
+        {
+          'changeType': 'MODIFIED',
+          'fieldName': 'LDR',
+          'fullPath': 'LDR',
+          'oldValue': '123  4500',
+          'newValue': '1234',
+        },
+      ],
+    },
+  }],
+  totalRecords,
+  isLoading: false,
+};
 
 const onCloseMock = jest.fn();
 const marcId = 'marcId';
 
-const renderMarcVersionHistory = () => render(
+const getComponent = (props = {}) => (
   <Harness>
     <MarcVersionHistory
       id={marcId}
       onClose={onCloseMock}
       marcType="bib"
       tenantId="tenant-id"
+      {...props}
     />
-  </Harness>,
+  </Harness>
 );
+
+const renderMarcVersionHistory = (props) => render(getComponent(props));
 
 describe('MarcVersionHistory', () => {
   const scrollIntoViewOriginal = Element.prototype.scrollIntoView;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    useMarcAuditDataQuery.mockReturnValue(auditDataResponse);
   });
 
   beforeAll(() => {
@@ -142,6 +148,34 @@ describe('MarcVersionHistory', () => {
     renderMarcVersionHistory();
 
     expect(screen.getByText(totalRecords)).toBeInTheDocument();
+  });
+
+  it('should display previous totalRecords during loading', () => {
+    const { rerender } = renderMarcVersionHistory();
+
+    useMarcAuditDataQuery.mockReturnValue({
+      data: [],
+      totalRecords: undefined,
+      isLoading: true,
+    });
+
+    rerender(getComponent());
+
+    expect(screen.getByText(totalRecords)).toBeInTheDocument();
+  });
+
+  it('should display a loader inside LoadMore button during loading', () => {
+    const { rerender } = renderMarcVersionHistory();
+
+    useMarcAuditDataQuery.mockReturnValue({
+      data: [],
+      totalRecords: undefined,
+      isLoading: true,
+    });
+
+    rerender(getComponent());
+
+    expect(screen.getByText('stripes-components.auditLog.pane.loadingLabel')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION

## Purpose
Display loading for the LoadMore button.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
https://folio-org.atlassian.net/browse/UISMRCCOMP-28

## Approach
Pass `totalVersions` instead of `totalRecords` to the `useVersionHistory`, as `totalRecords` becomes undefined during loading.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots

https://github.com/user-attachments/assets/ac2c8eec-43b2-4ff1-9018-b61fbb86d7dc



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
