### PR TITLE
UISMRCCOMP-31: MarcVersionHistory - add a new `isSharedFromLocalRecord` prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [UISMRCCOMP-30](https://issues.folio.org/browse/UISMRCCOMP-30) MarcView - accept a new `paneProps` prop.
 
+## [2.0.1] (IN PROGRESS)
+
+- [UISMRCCOMP-31](https://issues.folio.org/browse/UISMRCCOMP-31) MarcVersionHistory - add a new `isSharedFromLocalRecord` prop.
+
 ## [2.0.0] (https://github.com/folio-org/stripes-marc-components/tree/v2.0.0) (2025-03-13)
 
 - [UISMRCCOMP-19](https://issues.folio.org/browse/UISMRCCOMP-19) *BREAKING* migrate stripes dependencies to their Sunflower versions.

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -24,6 +24,7 @@ import { MODAL_COLUMN_WIDTHS } from './constants';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
+  isSharedFromLocalRecord: PropTypes.bool,
   marcType: PropTypes.oneOf(['bib', 'authority']).isRequired,
   onClose: PropTypes.func.isRequired,
   tenantId: PropTypes.string.isRequired,
@@ -34,6 +35,7 @@ const MarcVersionHistory = ({
   id,
   onClose,
   tenantId,
+  isSharedFromLocalRecord = false,
 }) => {
   const stripes = useStripes();
   const intl = useIntl();
@@ -93,6 +95,7 @@ const MarcVersionHistory = ({
       onClose={onClose}
       totalVersions={totalVersions}
       isLoading={isLoading}
+      showSharedLabel={isSharedFromLocalRecord}
       columnWidths={MODAL_COLUMN_WIDTHS}
     />
   );


### PR DESCRIPTION

## Purpose
Add the `isSharedFromLocalRecord` property to display the "Shared" label for the original card.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Related PRs
https://github.com/folio-org/stripes-components/pull/2452

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issue
[UISMRCCOMP-31](https://folio-org.atlassian.net/browse/UISMRCCOMP-31)

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
