### PR TITLE
UISMRCCOMP-29 Add loading indicator to MARC version history panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISMRCCOMP-30](https://issues.folio.org/browse/UISMRCCOMP-30) MarcView - accept a new `paneProps` prop.
 - [UISMRCCOMP-31](https://issues.folio.org/browse/UISMRCCOMP-31) MarcVersionHistory - add a new `isSharedFromLocalRecord` prop.
 - [UISMRCCOMP-32](https://issues.folio.org/browse/UISMRCCOMP-32) Use central tenant id in useUsersBatch to retrieve all users.
+- [UISMRCCOMP-29](https://issues.folio.org/browse/UISMRCCOMP-29) Add loading indicator to MARC version history panes.
 
 ## [2.0.1] (IN PROGRESS)
 

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -40,14 +40,15 @@ const MarcVersionHistory = ({
   const stripes = useStripes();
   const intl = useIntl();
   const [usersMap, setUsersMap] = useState({});
-  const [lastVersionEventTs, setLastVersionEventTs] = useState(null);
   const [totalVersions, setTotalVersions] = useState(0);
 
   const {
     data,
     totalRecords,
     isLoading,
-  } = useMarcAuditDataQuery(id, marcType, lastVersionEventTs, tenantId);
+    isLoadingMore,
+    fetchNextPage,
+  } = useMarcAuditDataQuery(id, marcType, tenantId);
 
   const usersId = useMemo(() => uniq(data?.map(version => version.userId)), [data]);
   const hasUsersViewPerm = stripes.hasPerm('ui-users.view');
@@ -83,20 +84,17 @@ const MarcVersionHistory = ({
     }
   }, [totalRecords]);
 
-  const handleLoadMore = lastEventTs => {
-    setLastVersionEventTs(lastEventTs);
-  };
-
   return (
     <AuditLogPane
       versions={versions}
       isLoadMoreVisible={isLoadMoreVisible}
-      handleLoadMore={handleLoadMore}
+      handleLoadMore={() => fetchNextPage()}
       actionsMap={actionsMap}
       onClose={onClose}
       totalVersions={totalVersions}
-      isLoading={isLoading}
       showSharedLabel={isSharedFromLocalRecord}
+      isLoading={isLoadingMore}
+      isInitialLoading={isLoading}
       columnWidths={MODAL_COLUMN_WIDTHS}
     />
   );

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -48,6 +48,7 @@ const MarcVersionHistory = ({
     isLoading,
     isLoadingMore,
     fetchNextPage,
+    hasNextPage,
   } = useMarcAuditDataQuery(id, marcType, tenantId);
 
   const usersId = useMemo(() => uniq(data?.map(version => version.userId)), [data]);
@@ -68,12 +69,8 @@ const MarcVersionHistory = ({
 
   const actionsMap = { ...getActionLabel(intl.formatMessage) };
 
-  const {
-    versions,
-    isLoadMoreVisible,
-  } = useVersionHistory({
+  const { versions } = useVersionHistory({
     data,
-    totalRecords: totalVersions,
     versionsFormatter: versionsFormatter(usersMap, intl, hasUsersViewPerm),
   });
 
@@ -87,7 +84,7 @@ const MarcVersionHistory = ({
   return (
     <AuditLogPane
       versions={versions}
-      isLoadMoreVisible={isLoadMoreVisible}
+      isLoadMoreVisible={hasNextPage}
       handleLoadMore={() => fetchNextPage()}
       actionsMap={actionsMap}
       onClose={onClose}

--- a/lib/MarcVersionHistory/MarcVersionHistory.test.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.test.js
@@ -68,6 +68,7 @@ const auditDataResponse = {
   }],
   totalRecords,
   isLoading: false,
+  fetchNextPage: jest.fn(),
 };
 
 const onCloseMock = jest.fn();
@@ -113,15 +114,13 @@ describe('MarcVersionHistory', () => {
   });
 
   describe('when clicking on Load more button', () => {
-    it('should make a new request with eventTs parameter', () => {
+    it('should make a new request', () => {
       renderMarcVersionHistory();
 
       useMarcAuditDataQuery.mockClear();
       fireEvent.click(screen.getByRole('button', { name: 'stripes-components.mcl.loadMore' }));
 
-      const eventTs = 1741264744302; // timestamp of unix time
-
-      expect(useMarcAuditDataQuery).toHaveBeenCalledWith(marcId, 'bib', eventTs, 'tenant-id');
+      expect(auditDataResponse.fetchNextPage).toHaveBeenCalled();
     });
   });
 
@@ -157,6 +156,7 @@ describe('MarcVersionHistory', () => {
       data: [],
       totalRecords: undefined,
       isLoading: true,
+      fetchNextPage: jest.fn(),
     });
 
     rerender(getComponent());
@@ -170,7 +170,9 @@ describe('MarcVersionHistory', () => {
     useMarcAuditDataQuery.mockReturnValue({
       data: [],
       totalRecords: undefined,
-      isLoading: true,
+      isLoading: false,
+      isLoadingMore: true,
+      fetchNextPage: jest.fn(),
     });
 
     rerender(getComponent());

--- a/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
+++ b/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
@@ -55,6 +55,8 @@ export const useMarcAuditDataQuery = (id, marcType, tenantId) => {
     totalRecords,
     isLoading,
     isLoadingMore: isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
     ...rest,
   };
 };

--- a/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
+++ b/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
@@ -1,29 +1,60 @@
-import { useQuery } from 'react-query';
+import { useMemo } from 'react';
+import { useInfiniteQuery } from 'react-query';
 
 import {
   useNamespace,
   useOkapiKy,
 } from '@folio/stripes/core';
 
-export const useMarcAuditDataQuery = (id, marcType, eventTs, tenantId) => {
+export const useMarcAuditDataQuery = (id, marcType, tenantId) => {
   const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'marc-audit-data' });
 
-  // eventTs param is used to load more data
-  const { isLoading, data = {} } = useQuery({
-    queryKey: [namespace, id, marcType, eventTs, tenantId],
-    queryFn: () => ky.get(`audit-data/marc/${marcType}/${id}`, {
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    ...rest
+  } = useInfiniteQuery({
+    queryKey: [namespace, id, marcType, tenantId],
+    queryFn: ({ pageParam }) => ky.get(`audit-data/marc/${marcType}/${id}`, {
       searchParams: {
-        ...(eventTs && { eventTs }),
+        ...(pageParam && { eventTs: pageParam }),
       },
     }).json(),
+    getNextPageParam: (lastPage, allPages) => {
+      const totalRecords = lastPage?.totalRecords || 0;
+      const totalFetchedItems = allPages.reduce((sum, page) => {
+        return sum + (page?.marcAuditItems?.length || 0);
+      }, 0);
+
+      // if we've fetched all records, return undefined to disable further loading
+      if (totalFetchedItems >= totalRecords) {
+        return undefined;
+      }
+
+      // otherwise, return the timestamp of the last item for the next page
+      const items = lastPage?.marcAuditItems || [];
+
+      return items.length > 0 ? items[items.length - 1].eventTs : undefined;
+    },
     enabled: Boolean(id),
     cacheTime: 0,
   });
 
+  // flatten all pages into a single array
+  const flattenedData = useMemo(() => {
+    return data?.pages?.flatMap(page => page?.marcAuditItems || []) || [];
+  }, [data]);
+  const totalRecords = data?.pages?.[0]?.totalRecords || 0;
+
   return {
-    data: data?.marcAuditItems || [],
-    totalRecords: data?.totalRecords,
+    data: flattenedData,
+    totalRecords,
     isLoading,
+    isLoadingMore: isFetchingNextPage,
+    ...rest,
   };
 };

--- a/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.test.js
+++ b/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.test.js
@@ -6,6 +6,7 @@ import {
 import {
   renderHook,
   act,
+  waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 import { useOkapiKy } from '@folio/stripes/core';
 
@@ -20,10 +21,18 @@ const wrapper = ({ children }) => (
 );
 
 describe('useMarcAuditDataQuery', () => {
+  const mockAuditData = {
+    totalRecords: 3,
+    marcAuditItems: [
+      { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+      { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+    ],
+  };
+
   beforeEach(() => {
     useOkapiKy.mockClear().mockReturnValue({
       get: () => ({
-        json: jest.fn().mockResolvedValue({ marcAuditItems: [{ diff: [] }] }),
+        json: jest.fn().mockResolvedValue(mockAuditData),
       }),
     });
   });
@@ -37,6 +46,72 @@ describe('useMarcAuditDataQuery', () => {
 
     await act(() => !result.current.isLoading);
 
-    expect(result.current.data).toEqual([{ diff: [] }]);
+    expect(result.current.data).toEqual(mockAuditData.marcAuditItems);
+  });
+
+  it('should handle fetchNextPage correctly', async () => {
+    const secondPageData = {
+      totalRecords: 3,
+      marcAuditItems: [
+        { eventTs: '2024-03-20T08:00:00Z', id: '3' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(mockAuditData),
+        }),
+      })
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(secondPageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useMarcAuditDataQuery('id'),
+      { wrapper },
+    );
+
+    await act(() => !result.current.isLoading);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(3);
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+  });
+
+  it('should set hasNextPage to false when all records are fetched', async () => {
+    const singlePageData = {
+      totalRecords: 2,
+      marcAuditItems: [
+        { eventTs: '2024-03-20T10:00:00Z', id: '1' },
+        { eventTs: '2024-03-20T09:00:00Z', id: '2' },
+      ],
+    };
+
+    useOkapiKy
+      .mockClear()
+      .mockReturnValueOnce({
+        get: () => ({
+          json: () => Promise.resolve(singlePageData),
+        }),
+      });
+
+    const { result } = renderHook(
+      () => useMarcAuditDataQuery('id'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasNextPage).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Description
Re-write (shamelessly steal from Inventory) code to fetch audit data
Use separate `isLoading` and `isLoadingMore` props for `<AuditLogPane>`

## Screenshots

https://github.com/user-attachments/assets/aae04707-2fae-4cef-bef7-718b9cc8327a



## Issues
[UISMRCCOMP-29](https://folio-org.atlassian.net/browse/UISMRCCOMP-29)