### PR TITLE
UISMRCCOMP-34 Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-marc-components
 
+## [2.1.0] (IN PROGRESS)
+
+- [UISMRCCOMP-34](https://issues.folio.org/browse/UISMRCCOMP-34) Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.
+
 ## [2.0.1] (https://github.com/folio-org/stripes-marc-components/tree/v2.0.1) (2025-04-11)
 
 - [UISMRCCOMP-30](https://issues.folio.org/browse/UISMRCCOMP-30) MarcView - accept a new `paneProps` prop.

--- a/lib/queries/useAuthorityLinkingRules/useAuthorityLinkingRules.js
+++ b/lib/queries/useAuthorityLinkingRules/useAuthorityLinkingRules.js
@@ -6,7 +6,7 @@ import {
 } from '@folio/stripes/core';
 
 const useAuthorityLinkingRules = ({ tenantId } = {}) => {
-  const ky = useOkapiKy({ tenantId });
+  const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'authority-linking-rules' });
 
   const { isFetching, data } = useQuery(


### PR DESCRIPTION
## Description
Pass correct `tenant` parameter to `useOkapiKy`, instead of incorrect `tenantId`.

## Issues
[UISMRCCOMP-34](https://folio-org.atlassian.net/browse/UISMRCCOMP-34)