### PR TITLE
UISMRCCOMP-38 Make `instance-authority-linking-rules` interface optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.1.0] (IN PROGRESS)
 
 - [UISMRCCOMP-34](https://issues.folio.org/browse/UISMRCCOMP-34) Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.
+- [UISMRCCOMP-38](https://issues.folio.org/browse/UISMRCCOMP-38) Make `instance-authority-linking-rules` interface optional.
 
 ## [2.0.1] (https://github.com/folio-org/stripes-marc-components/tree/v2.0.1) (2025-04-11)
 

--- a/lib/queries/useAuthorityLinkingRules/useAuthorityLinkingRules.js
+++ b/lib/queries/useAuthorityLinkingRules/useAuthorityLinkingRules.js
@@ -3,9 +3,11 @@ import { useQuery } from 'react-query';
 import {
   useNamespace,
   useOkapiKy,
+  useStripes,
 } from '@folio/stripes/core';
 
 const useAuthorityLinkingRules = ({ tenantId } = {}) => {
+  const stripes = useStripes();
   const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'authority-linking-rules' });
 
@@ -13,6 +15,9 @@ const useAuthorityLinkingRules = ({ tenantId } = {}) => {
     [namespace],
     async () => {
       return ky.get('linking-rules/instance-authority').json();
+    },
+    {
+      enabled: stripes.hasInterface('instance-authority-linking-rules'),
     },
   );
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
       ""
     ],
     "okapiInterfaces": {
-      "instance-authority-linking-rules": "1.1",
       "audit-marc": "1.0"
+    },
+    "optionalOkapiInterfaces": {
+      "instance-authority-linking-rules": "1.1"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description
Make `instance-authority-linking-rules` interface optional.

## Issues
[UISMRCCOMP-38](https://folio-org.atlassian.net/browse/UISMRCCOMP-38)