### PR TITLE
UISMRCCOMP-39 Handle audit-marc dependency: hide audit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UISMRCCOMP-34](https://issues.folio.org/browse/UISMRCCOMP-34) Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.
 - [UISMRCCOMP-38](https://issues.folio.org/browse/UISMRCCOMP-38) Make `instance-authority-linking-rules` interface optional.
+- [UISMRCCOMP-39](https://issues.folio.org/browse/UISMRCCOMP-39) Handle `audit-marc` dependency: hide audit button.
 
 ## [2.0.1] (https://github.com/folio-org/stripes-marc-components/tree/v2.0.1) (2025-04-11)
 

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -81,6 +81,10 @@ const MarcVersionHistory = ({
     }
   }, [totalRecords]);
 
+  if (!stripes.hasInterface('audit-marc')) {
+    return null;
+  }
+
   return (
     <AuditLogPane
       versions={versions}

--- a/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
+++ b/lib/queries/useMarcAuditDataQuery/useMarcAuditDataQuery.js
@@ -4,9 +4,11 @@ import { useInfiniteQuery } from 'react-query';
 import {
   useNamespace,
   useOkapiKy,
+  useStripes,
 } from '@folio/stripes/core';
 
 export const useMarcAuditDataQuery = (id, marcType, tenantId) => {
+  const stripes = useStripes();
   const ky = useOkapiKy({ tenant: tenantId });
   const [namespace] = useNamespace({ key: 'marc-audit-data' });
 
@@ -40,7 +42,7 @@ export const useMarcAuditDataQuery = (id, marcType, tenantId) => {
 
       return items.length > 0 ? items[items.length - 1].eventTs : undefined;
     },
-    enabled: Boolean(id),
+    enabled: Boolean(id) && stripes.hasInterface('audit-marc'),
     cacheTime: 0,
   });
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "actsAs": [
       ""
     ],
-    "okapiInterfaces": {
-      "audit-marc": "1.0"
-    },
     "optionalOkapiInterfaces": {
-      "instance-authority-linking-rules": "1.1"
+      "instance-authority-linking-rules": "1.1",
+      "audit-marc": "1.0"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description
Part of split application work. Make `audit-marc` dependency optional and check for it's presence in components that use it

## Issues
[UISMRCCOMP-39](https://folio-org.atlassian.net/browse/UISMRCCOMP-39)