### PR TITLE
UISMRCCOMP-41 Remove usage of `useVersionHistory` hook because it accumulates version history data, resulting in duplicate cards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISMRCCOMP-34](https://issues.folio.org/browse/UISMRCCOMP-34) Use Central tenant linking rules when user editing Shared MARC bib from Central or Member tenant.
 - [UISMRCCOMP-38](https://issues.folio.org/browse/UISMRCCOMP-38) Make `instance-authority-linking-rules` interface optional.
 - [UISMRCCOMP-39](https://issues.folio.org/browse/UISMRCCOMP-39) Handle `audit-marc` dependency: hide audit button.
+- [UISMRCCOMP-41](https://issues.folio.org/browse/UISMRCCOMP-41) Remove usage of `useVersionHistory` hook because it accumulates version history data, resulting in duplicate cards.
 
 ## [2.0.1] (https://github.com/folio-org/stripes-marc-components/tree/v2.0.1) (2025-04-11)
 

--- a/lib/MarcVersionHistory/MarcVersionHistory.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.js
@@ -9,10 +9,7 @@ import uniq from 'lodash/uniq';
 import keyBy from 'lodash/keyBy';
 
 import { useStripes } from '@folio/stripes/core';
-import {
-  AuditLogPane,
-  useVersionHistory,
-} from '@folio/stripes/components';
+import { AuditLogPane } from '@folio/stripes/components';
 import { useUsersBatch } from '@folio/stripes-acq-components';
 
 import { useMarcAuditDataQuery } from '../queries';
@@ -69,10 +66,12 @@ const MarcVersionHistory = ({
 
   const actionsMap = { ...getActionLabel(intl.formatMessage) };
 
-  const { versions } = useVersionHistory({
+  const versions = useMemo(() => versionsFormatter(usersMap, intl, hasUsersViewPerm)(data), [
+    usersMap,
+    intl,
+    hasUsersViewPerm,
     data,
-    versionsFormatter: versionsFormatter(usersMap, intl, hasUsersViewPerm),
-  });
+  ]);
 
   useEffect(() => {
     // totalRecords always returns undefined while loading, and we need to display the total number of versions.

--- a/lib/MarcVersionHistory/MarcVersionHistory.test.js
+++ b/lib/MarcVersionHistory/MarcVersionHistory.test.js
@@ -1,78 +1,97 @@
-import { useStripes } from '@folio/stripes/core';
 import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
-
+import {
+  useStripes,
+  useOkapiKy,
+} from '@folio/stripes/core';
 import { useUsersBatch } from '@folio/stripes-acq-components';
+
 import { MarcVersionHistory } from './MarcVersionHistory';
-import { useMarcAuditDataQuery } from '../queries';
+
 import buildStripes from '../../test/jest/__mock__/stripesCore.mock';
 import Harness from '../../test/jest/helpers/harness';
 
 const mockHasPerm = jest.fn().mockReturnValue(true);
-const totalRecords = 123;
-
-jest.mock('../queries', () => ({
-  ...jest.requireActual('../queries'),
-  useMarcAuditDataQuery: jest.fn(),
-}));
+const totalRecords = 3;
 
 const auditDataResponse = {
-  data: [{
-    eventDate: '1970-01-01T00:00:00+00:00',
-    action: 'UPDATED',
-    eventTs: 1741264744302,
-    userId: 'user-id',
-    diff: {
-      collectionChanges: [{
-        'collectionName': '750',
-        'itemChanges': [
-          {
-            'changeType': 'REMOVED',
-            'oldValue': ' 0 $a Black people $0 (DLC)sh 85014672 ',
-            'newValue': null,
-          },
-          {
-            'changeType': 'ADDED',
-            'oldValue': null,
-            'newValue': ' 0 $a Black people $0 (DLC)sh 85014672',
-          },
-        ],
+  marcAuditItems: [{
+    'eventId': '3662b23d-f69a-4992-b116-3f50248f8fe7',
+    'entityId': '4027355e-9095-5577-8b5d-c7bffe9d3597',
+    'eventDate': '2026-04-01T15:52:04.004+00:00',
+    'eventTs': 1775058724004,
+    'origin': 'mod-source-record-storage-5.10.15',
+    'action': 'UPDATED',
+    'userId': 'user-id',
+    'diff': {
+      'fieldChanges': [{
+        'changeType': 'MODIFIED',
+        'fieldName': '100',
+        'fullPath': '100',
+        'oldValue': '1  $a Freeman, Carroll edit 10',
+        'newValue': '1  $a Freeman, Carroll edit 11',
       }],
-      fieldChanges: [
-        {
-          'changeType': 'MODIFIED',
-          'fieldName': '150',
-          'fullPath': '150',
-          'oldValue': '   $a foo',
-          'newValue': '   $a foo test',
-        },
-        {
-          'changeType': 'MODIFIED',
-          'fieldName': '003',
-          'fullPath': '003',
-          'oldValue': 'OCoLC',
-          'newValue': '$a OCoLC',
-        },
-        {
-          'changeType': 'MODIFIED',
-          'fieldName': 'LDR',
-          'fullPath': 'LDR',
-          'oldValue': '123  4500',
-          'newValue': '1234',
-        },
-      ],
+      'collectionChanges': [],
     },
   }],
   totalRecords,
-  isLoading: false,
-  fetchNextPage: jest.fn(),
+};
+
+const auditDataResponseWithNextPage = {
+  marcAuditItems: [{
+    'eventId': '60e38210-70f7-48b2-8a99-c24af9ad9331',
+    'entityId': '4027355e-9095-5577-8b5d-c7bffe9d3597',
+    'eventDate': '2026-04-01T15:51:57.741+00:00',
+    'eventTs': 1775058717741,
+    'origin': 'mod-source-record-storage-5.10.15',
+    'action': 'UPDATED',
+    'userId': 'user-id',
+    'diff': {
+      'fieldChanges': [{
+        'changeType': 'MODIFIED',
+        'fieldName': '100',
+        'fullPath': '100',
+        'oldValue': '1  $a Freeman, Carroll edit 9',
+        'newValue': '1  $a Freeman, Carroll edit 10',
+      }, {
+        'changeType': 'MODIFIED',
+        'fieldName': 'LDR',
+        'fullPath': 'LDR',
+        'oldValue': '00461nz  a2200145n  4500',
+        'newValue': '00462nz  a2200145n  4500',
+      }],
+      'collectionChanges': [],
+    },
+  }, {
+    'eventId': '09f5d973-39f4-4a9e-8de7-2a713c074445',
+    'entityId': '4027355e-9095-5577-8b5d-c7bffe9d3597',
+    'eventDate': '2026-04-01T15:51:51.135+00:00',
+    'eventTs': 1775058711135,
+    'origin': 'mod-source-record-storage-5.10.15',
+    'action': 'UPDATED',
+    'userId': 'user-id',
+    'diff': {
+      'fieldChanges': [{
+        'changeType': 'MODIFIED',
+        'fieldName': '100',
+        'fullPath': '100',
+        'oldValue': '1  $a Freeman, Carroll edit 8',
+        'newValue': '1  $a Freeman, Carroll edit 9',
+      }],
+      'collectionChanges': [],
+    },
+  }],
+  totalRecords,
 };
 
 const onCloseMock = jest.fn();
 const marcId = 'marcId';
+
+const mockGet = jest.fn();
 
 const getComponent = (props = {}) => (
   <Harness>
@@ -93,9 +112,14 @@ describe('MarcVersionHistory', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useMarcAuditDataQuery.mockReturnValue(auditDataResponse);
     useStripes.mockReturnValue(buildStripes({
       hasPerm: mockHasPerm,
+    }));
+    useOkapiKy.mockReturnValue({
+      get: mockGet,
+    });
+    mockGet.mockImplementation(() => ({
+      json: jest.fn().mockResolvedValue(auditDataResponse),
     }));
   });
 
@@ -114,73 +138,67 @@ describe('MarcVersionHistory', () => {
   });
 
   describe('when clicking on Load more button', () => {
-    it('should make a new request', () => {
+    it('should display the next page with the correct total number of cards', async () => {
       renderMarcVersionHistory();
 
-      useMarcAuditDataQuery.mockClear();
-      fireEvent.click(screen.getByRole('button', { name: 'stripes-components.mcl.loadMore' }));
+      mockGet.mockReturnValue({
+        json: jest.fn().mockResolvedValue(auditDataResponseWithNextPage),
+      });
 
-      expect(auditDataResponse.fetchNextPage).toHaveBeenCalled();
+      await waitFor(() => fireEvent.click(screen.getByRole('button', { name: 'stripes-components.mcl.loadMore' })));
+
+      await waitFor(() => expect(screen.getAllByText('stripes-components.auditLog.card.changed')).toHaveLength(3));
     });
   });
 
   describe('when there is a user view permission', () => {
-    it('should display username as a link', () => {
+    it('should display username as a link', async () => {
       renderMarcVersionHistory();
 
-      expect(screen.getByRole('link', { name: 'lastName, firstName' })).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByRole('link', { name: 'lastName, firstName' })).toBeInTheDocument());
     });
   });
 
   describe('when there is no a user view permission', () => {
-    it('should display username as not a link', () => {
+    it('should display username as not a link', async () => {
       mockHasPerm.mockReturnValue(false);
 
       renderMarcVersionHistory();
 
-      expect(screen.queryByRole('link', { name: 'lastName, firstName' })).toBeNull();
-      expect(screen.getByText('lastName, firstName')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByRole('link', { name: 'lastName, firstName' })).toBeNull();
+        expect(screen.getByText('lastName, firstName')).toBeInTheDocument();
+      });
     });
   });
 
-  it('should render the total number of records in a header', () => {
+  it('should render the total number of records in a header', async () => {
     renderMarcVersionHistory();
 
-    expect(screen.getByText(totalRecords)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(totalRecords)).toBeInTheDocument());
   });
 
-  it('should display previous totalRecords during loading', () => {
-    const { rerender } = renderMarcVersionHistory();
+  describe('when loading more audit data', () => {
+    beforeEach(async () => {
+      renderMarcVersionHistory();
 
-    useMarcAuditDataQuery.mockReturnValue({
-      data: [],
-      totalRecords: undefined,
-      isLoading: true,
-      fetchNextPage: jest.fn(),
+      mockGet.mockReturnValue({
+        json: jest.fn().mockImplementation(() => new Promise()),
+      });
+
+      await waitFor(() => fireEvent.click(screen.getByRole('button', { name: 'stripes-components.mcl.loadMore' })));
     });
 
-    rerender(getComponent());
-
-    expect(screen.getByText(totalRecords)).toBeInTheDocument();
-  });
-
-  it('should display a loader inside LoadMore button during loading', () => {
-    const { rerender } = renderMarcVersionHistory();
-
-    useMarcAuditDataQuery.mockReturnValue({
-      data: [],
-      totalRecords: undefined,
-      isLoading: false,
-      isLoadingMore: true,
-      fetchNextPage: jest.fn(),
+    it('should display previous totalRecords', () => {
+      expect(screen.getByText(totalRecords)).toBeInTheDocument();
     });
 
-    rerender(getComponent());
-
-    expect(screen.getByText('stripes-components.auditLog.pane.loadingLabel')).toBeInTheDocument();
+    it('should display a loader inside LoadMore button', () => {
+      expect(screen.getByText('stripes-components.auditLog.pane.loadingLabel')).toBeInTheDocument();
+    });
   });
 
-  it('should fetch users from central tenant', () => {
+  it('should fetch users from central tenant', async () => {
     const centralTenantId = 'central-tenant-id';
     const usersId = ['user-id'];
 
@@ -197,7 +215,7 @@ describe('MarcVersionHistory', () => {
 
     renderMarcVersionHistory();
 
-    expect(useUsersBatch).toHaveBeenCalledWith(usersId, { tenantId: centralTenantId });
+    await waitFor(() => expect(useUsersBatch).toHaveBeenCalledWith(usersId, { tenantId: centralTenantId }));
   });
 });
 


### PR DESCRIPTION
## Description
MARC Version history pane has duplicated cards after loading a next page.
The root cause lies in the `useVersionHistory` hook - it accumulates passed data, but in case of MARC Version history the pages are also accumulated in `useMarcAuditDataQuery` hook.
In our case it is better to remove the use of `useVersionHistory` hook because it doesn't provide much functionality.

## Issues
[UISMRCCOMP-41](https://folio-org.atlassian.net/browse/UISMRCCOMP-41)